### PR TITLE
Fix script loading on plugin startup and settings UI update

### DIFF
--- a/packages/obsidian-plugin/src/settings/setting-tab.ts
+++ b/packages/obsidian-plugin/src/settings/setting-tab.ts
@@ -154,6 +154,7 @@ export class MCPSettingTab extends PluginSettingTab {
 			.addButton((button) =>
 				button.setButtonText("Reload").onClick(async () => {
 					await this.settingsStore.reloadScripts();
+					this.display();
 				}),
 			);
 

--- a/packages/obsidian-script-loader/src/adapters/obsidian-vault-adapter.ts
+++ b/packages/obsidian-script-loader/src/adapters/obsidian-vault-adapter.ts
@@ -134,6 +134,13 @@ export class ObsidianVaultAdapter implements ScriptHost {
 			await this.vault.createFolder(normalizedPath);
 		} catch (error) {
 			// Obsidian can throw "Folder already exists." for existing paths (e.g. trailing slash or race).
+			// If the error message indicates the folder already exists, treat it as success
+			// even if the cache hasn't updated yet
+			if (error instanceof Error && error.message === "Folder already exists.") {
+				return;
+			}
+			// For other errors, wait briefly for cache to update, then retry
+			await new Promise(resolve => setTimeout(resolve, 100));
 			const retry = this.vault.getAbstractFileByPath(normalizedPath);
 			if (retry instanceof TFolder) {
 				return;


### PR DESCRIPTION
## Summary
Fixes two issues related to script loading and settings UI updates.

## Issues Fixed

### 1. Scripts not loading on plugin startup
**Problem:** Scripts were not being loaded when the plugin starts up, but would load successfully when the "Reload" button is pressed.

**Root Cause:** Obsidian's internal cache doesn't update immediately after creating a folder. When `vault.createFolder()` throws "Folder already exists" error, the retry using `getAbstractFileByPath()` returns `null` because the cache hasn't updated yet.

**Solution:** Treat "Folder already exists." error as success in `ensureDirectory()`, since the error message itself confirms the folder exists.

### 2. Settings UI not updating after reload
**Problem:** When the "Reload scripts" button is pressed, scripts are reloaded but the settings UI doesn't reflect the changes.

**Solution:** Call `this.display()` after `reloadScripts()` to refresh the settings UI.

## Changes

- `packages/obsidian-plugin/src/settings/setting-tab.ts`: Add `this.display()` call after reload
- `packages/obsidian-script-loader/src/adapters/obsidian-vault-adapter.ts`: Handle "Folder already exists" error as success

## Test Plan
- [x] Plugin starts successfully and loads scripts on startup
- [x] Reload button updates the settings UI with newly loaded scripts
- [x] No errors in console during plugin startup

🤖 Generated with Claude Code