### PR TITLE
Fix read_note path normalization for case-insensitive .md check

### DIFF
--- a/packages/obsidian-plugin/src/mcp/tools/builtin/notes.ts
+++ b/packages/obsidian-plugin/src/mcp/tools/builtin/notes.ts
@@ -1,4 +1,4 @@
-import { TFile } from "obsidian";
+import { normalizePath, TFile } from "obsidian";
 import { MCPToolDefinition, MCPToolResult } from "../types";
 
 /**
@@ -21,9 +21,11 @@ export const readNoteTool: MCPToolDefinition = {
 	handler: async (args, context): Promise<MCPToolResult> => {
 		const path = args.path as string;
 
-		// Normalize path: add .md if not present
-		let normalizedPath = path;
-		if (!normalizedPath.endsWith(".md")) {
+		// Normalize path using Obsidian's helper (handles path separators)
+		let normalizedPath = normalizePath(path);
+
+		// Add .md extension if not present (case-insensitive check)
+		if (!normalizedPath.toLowerCase().endsWith(".md")) {
 			normalizedPath = `${normalizedPath}.md`;
 		}
 


### PR DESCRIPTION
- Use normalizePath() to handle path separators across OS
- Add case-insensitive extension check to prevent Foo.MD -> Foo.MD.md
- Fixes issue where valid notes fail to resolve with uppercase extensions

Resolves #12

https://claude.ai/code/session_01CHfpgR2UEMX7hPXcuVQdnn