### PR TITLE
Align stdio-bridge E2E scope with plan: full integration + fallback-only fake HTTP

### DIFF
--- a/packages/stdio-bridge/package.json
+++ b/packages/stdio-bridge/package.json
@@ -12,7 +12,8 @@
 		"prebuild": "pnpm --filter @obsiscripta/shared run build",
 		"build": "tsc -p tsconfig.json --emitDeclarationOnly && node esbuild.config.mjs production",
 		"dev": "node esbuild.config.mjs",
-		"build:binary": "node esbuild.config.mjs production && mkdir -p dist/pkg && PKG_CACHE_PATH=.pkg-cache pkg --targets node18-linux-x64,node18-win-x64 --out-path dist/pkg dist/obsidian-mcp.cjs"
+		"build:binary": "node esbuild.config.mjs production && mkdir -p dist/pkg && PKG_CACHE_PATH=.pkg-cache pkg --targets node18-linux-x64,node18-win-x64 --out-path dist/pkg dist/obsidian-mcp.cjs",
+		"test:e2e": "vitest run"
 	},
 	"keywords": [
 		"obsidian",
@@ -25,7 +26,8 @@
 		"@types/node": "^20.19.30",
 		"esbuild": "0.25.5",
 		"pkg": "^5.8.1",
-		"typescript": "^5.9.3"
+		"typescript": "^5.9.3",
+		"vitest": "^2.1.8"
 	},
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.25.3",

--- a/packages/stdio-bridge/tests/plugin-client.e2e.test.ts
+++ b/packages/stdio-bridge/tests/plugin-client.e2e.test.ts
@@ -1,0 +1,97 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { afterEach, describe, expect, it } from 'vitest';
+import { PluginClient } from '../src/plugin-client.js';
+
+async function startFakeServer(
+  handler: (req: IncomingMessage, res: ServerResponse) => void,
+): Promise<{ port: number; close: () => Promise<void> }> {
+  const server = createServer(handler);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Failed to acquire test server port');
+  }
+  return {
+    port: address.port,
+    close: () => new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve()))),
+  };
+}
+
+const cleanup: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  while (cleanup.length > 0) {
+    const close = cleanup.pop();
+    if (close) {
+      await close();
+    }
+  }
+});
+
+describe('PluginClient Fake HTTP fallback E2E', () => {
+  it('falls back from MCP to v1 listTools in auto transport mode', async () => {
+    const fake = await startFakeServer((req, res) => {
+      if (req.method === 'POST' && req.url === '/mcp') {
+        res.statusCode = 502;
+        res.end(JSON.stringify({ error: 'mcp down', message: 'mcp down' }));
+        return;
+      }
+
+      if (req.method === 'GET' && req.url === '/bridge/v1/tools') {
+        res.setHeader('content-type', 'application/json');
+        res.end(
+          JSON.stringify({
+            tools: [
+              {
+                name: 'echo',
+                description: 'Echo tool',
+                inputSchema: { type: 'object', properties: {} },
+              },
+            ],
+            hash: 'abc123',
+          }),
+        );
+        return;
+      }
+
+      res.statusCode = 404;
+      res.end(JSON.stringify({ error: 'not found', message: 'not found' }));
+    });
+    cleanup.push(fake.close);
+
+    const client = new PluginClient({ port: fake.port, timeout: 200, transportMode: 'auto' });
+    const tools = await client.listTools();
+
+    expect(tools.tools).toHaveLength(1);
+    expect(tools.tools[0]?.name).toBe('echo');
+  });
+
+  it('does not fallback to v1 when transportMode is mcp', async () => {
+    let v1ToolsRequests = 0;
+
+    const fake = await startFakeServer((req, res) => {
+      if (req.method === 'POST' && req.url === '/mcp') {
+        res.statusCode = 502;
+        res.end(JSON.stringify({ error: 'mcp down', message: 'mcp down' }));
+        return;
+      }
+
+      if (req.method === 'GET' && req.url === '/bridge/v1/tools') {
+        v1ToolsRequests += 1;
+        res.statusCode = 200;
+        res.end(JSON.stringify({ tools: [], hash: 'should-not-be-used' }));
+        return;
+      }
+
+      res.statusCode = 404;
+      res.end(JSON.stringify({ error: 'not found', message: 'not found' }));
+    });
+    cleanup.push(fake.close);
+
+    const client = new PluginClient({ port: fake.port, timeout: 200, transportMode: 'mcp' });
+
+    await expect(client.listTools()).rejects.toMatchObject({
+      name: 'PluginClientError',
+    });
+    expect(v1ToolsRequests).toBe(0);
+  });
+});

--- a/packages/stdio-bridge/tests/script-loader-core.integration.test.ts
+++ b/packages/stdio-bridge/tests/script-loader-core.integration.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { BridgeServer } from '../../obsidian-plugin/src/mcp/server.js';
+import { ToolExecutor } from '../../obsidian-plugin/src/mcp/tools/executor.js';
+import { ToolRegistry, ToolSource } from '../../obsidian-plugin/src/mcp/tools/registry.js';
+import { validateAndConvertScriptExports } from '../../obsidian-plugin/src/mcp/tools/scripting/script-validator.js';
+import { PluginClient } from '../src/plugin-client.js';
+import { StdioBridgeServer } from '../src/bridge-server.js';
+import {
+  FunctionRuntime,
+  ScriptCompiler,
+  ScriptLoaderCore,
+  ScriptRegistry,
+  type ExecutionContextConfig,
+} from '../../script-loader-core/src/index.js';
+import {
+  MockLogger,
+  MockPathUtils,
+  MockScriptHost,
+  delay,
+} from '../../script-loader-core/src/__tests__/test-helpers.js';
+
+async function getFreePort(): Promise<number> {
+  const { createServer } = await import('node:net');
+  return await new Promise<number>((resolve, reject) => {
+    const server = createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        reject(new Error('Failed to resolve free port'));
+        return;
+      }
+      server.close((err) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve(address.port);
+      });
+    });
+  });
+}
+
+const cleanup: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  while (cleanup.length > 0) {
+    const fn = cleanup.pop();
+    if (fn) {
+      await fn();
+    }
+  }
+});
+
+describe('script-loader-core + ToolExecutor + BridgeServer + stdio-bridge full integration', () => {
+  it('propagates initial load and hot-reload updates through stdio-bridge tool execution', async () => {
+    const scriptHost = new MockScriptHost();
+    const pathUtils = new MockPathUtils();
+    const logger = new MockLogger();
+    const compiler = new ScriptCompiler();
+
+    const contextConfig: ExecutionContextConfig = {
+      variableNames: ['ctx'],
+      provideContext: () => ({ ctx: {} }),
+    };
+    const runtime = new FunctionRuntime(contextConfig, { pathUtils });
+    const scriptRegistry = new ScriptRegistry(runtime);
+
+    const toolRegistry = new ToolRegistry();
+    const executor = new ToolExecutor(toolRegistry, { vault: {}, app: {} } as never);
+
+    const scriptPath = 'mcp-tools/dynamic/echo.ts';
+    scriptHost.setFile(
+      scriptPath,
+      `export default {
+        description: 'Dynamic echo',
+        inputSchema: {
+          type: 'object',
+          properties: { text: { type: 'string' } },
+          required: ['text']
+        },
+        async handler(args) {
+          return { content: [{ type: 'text', text: 'dynamic:' + String(args.text ?? '') }] };
+        }
+      };`,
+      1000,
+    );
+
+    const loader = new ScriptLoaderCore(
+      scriptHost,
+      pathUtils,
+      logger,
+      scriptRegistry,
+      compiler,
+      runtime,
+      {},
+      'mcp-tools',
+      {
+        onScriptLoaded: (metadata, exports) => {
+          const tool = validateAndConvertScriptExports(exports, metadata.path, metadata.name);
+          toolRegistry.register(tool, ToolSource.Script);
+        },
+        onScriptUnloaded: (metadata) => {
+          toolRegistry.unregister(metadata.name);
+        },
+      },
+      20,
+    );
+
+    await loader.start();
+    cleanup.push(() => loader.stop());
+
+    const port = await getFreePort();
+    const bridgeServer = new BridgeServer(executor, port);
+    await bridgeServer.start();
+    cleanup.push(() => bridgeServer.stop());
+
+    const pluginClient = new PluginClient({ port, transportMode: 'mcp', timeout: 1000 });
+    const stdioBridge = new StdioBridgeServer(pluginClient, 50);
+
+    await stdioBridge.syncTools();
+    expect(stdioBridge.getPollingState().tools.has('dynamic/echo')).toBe(true);
+
+    const callResult = await stdioBridge.executeToolCall('dynamic/echo', { text: 'hello' });
+    expect(callResult.success).toBe(true);
+    expect(callResult.content[0]?.text).toBe('dynamic:hello');
+
+    scriptHost.updateFile(
+      scriptPath,
+      `export default {
+        description: 'Dynamic echo',
+        inputSchema: {
+          type: 'object',
+          properties: { text: { type: 'string' } },
+          required: ['text']
+        },
+        async handler(args) {
+          return { content: [{ type: 'text', text: 'dynamic-v2:' + String(args.text ?? '') }] };
+        }
+      };`,
+      2000,
+    );
+    scriptHost.triggerModify(scriptPath);
+    await delay(80);
+
+    await stdioBridge.syncTools();
+    const updatedResult = await stdioBridge.executeToolCall('dynamic/echo', { text: 'hello' });
+    expect(updatedResult.success).toBe(true);
+    expect(updatedResult.content[0]?.text).toBe('dynamic-v2:hello');
+  });
+});

--- a/packages/stdio-bridge/vitest.config.ts
+++ b/packages/stdio-bridge/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+  },
+  define: {
+    __BRIDGE_VERSION__: JSON.stringify('test'),
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@20.19.30)
 
 packages:
 
@@ -3626,6 +3629,14 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 1.2.0
 
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@20.19.30))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@20.19.30)
+
   '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.7))':
     dependencies:
       '@vitest/spy': 2.1.9
@@ -5804,6 +5815,24 @@ snapshots:
 
   vary@1.1.2: {}
 
+  vite-node@2.1.9(@types/node@20.19.30):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@20.19.30)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-node@2.1.9(@types/node@22.19.7):
     dependencies:
       cac: 6.7.14
@@ -5822,6 +5851,15 @@ snapshots:
       - supports-color
       - terser
 
+  vite@5.4.21(@types/node@20.19.30):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.6
+      rollup: 4.57.0
+    optionalDependencies:
+      '@types/node': 20.19.30
+      fsevents: 2.3.3
+
   vite@5.4.21(@types/node@22.19.7):
     dependencies:
       esbuild: 0.21.5
@@ -5830,6 +5868,41 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.7
       fsevents: 2.3.3
+
+  vitest@2.1.9(@types/node@20.19.30):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@20.19.30))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@20.19.30)
+      vite-node: 2.1.9(@types/node@20.19.30)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.30
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   vitest@2.1.9(@types/node@22.19.7):
     dependencies:


### PR DESCRIPTION
### Motivation
- Narrow the E2E surface to exactly what was requested: one full end-to-end integration that includes `ScriptLoaderCore` → `FunctionRuntime` → `ScriptRegistry` → `ToolExecutor` → `BridgeServer` → `StdioBridgeServer`, and a separate fake-HTTP test that only verifies `PluginClient` transport fallback behavior. 
- Avoid changing production runtime fallbacks for test convenience and instead inject test constants at test time.

### Description
- Removed the redundant `bridge-server.integration.test.ts` and added a single full integration test at `packages/stdio-bridge/tests/script-loader-core.integration.test.ts` that wires `ScriptLoaderCore`, `FunctionRuntime`, `ScriptRegistry`, `ToolExecutor`, `BridgeServer`, and `StdioBridgeServer` together and validates initial load, call, and hot-reload behavior. 
- Replaced the previous broader fake-HTTP tests with a focused `packages/stdio-bridge/tests/plugin-client.e2e.test.ts` that asserts `PluginClient` falls back from MCP to v1 in `transportMode='auto'` and does not fallback when `transportMode='mcp'`. 
- Restored production source references to `__BRIDGE_VERSION__` in `packages/obsidian-plugin/src/mcp/bridge-api.ts` and `packages/stdio-bridge/src/bridge-server.ts` and added a test-time definition in `packages/stdio-bridge/vitest.config.ts` to avoid changing runtime behavior for tests. 
- Added `vitest` dev dependency and a `test:e2e` script to `packages/stdio-bridge/package.json` and updated lockfile entries accordingly to enable the package-local E2E runs.

### Testing
- Ran `pnpm --filter obsidian-mcp-bridge run test:e2e` which executed the new E2E suite and reported all tests passed (`Tests 3 passed (3)`).
- Ran `pnpm --filter obsidian-mcp-bridge run build` and the package build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698acfc290a08329af85c48a04092726)