### PR TITLE
Add vault-safe module resolution for Obsidian script tools

### DIFF
--- a/packages/obsidian-plugin/src/mcp/tools/scripting/script-validator.ts
+++ b/packages/obsidian-plugin/src/mcp/tools/scripting/script-validator.ts
@@ -1,5 +1,14 @@
 import { MCPToolDefinition } from "../types";
 
+export function isToolDefinitionLike(exports: unknown): exports is Partial<MCPToolDefinition> {
+	if (!exports || typeof exports !== "object") {
+		return false;
+	}
+
+	const obj = exports as Partial<MCPToolDefinition>;
+	return Boolean(obj.description || obj.inputSchema || obj.handler);
+}
+
 /**
  * Validates that an exported object has the shape of an MCPToolDefinition.
  * The tool name is provided by the loader (derived from script path) rather than

--- a/packages/obsidian-plugin/src/plugin/tooling-manager.ts
+++ b/packages/obsidian-plugin/src/plugin/tooling-manager.ts
@@ -10,7 +10,7 @@ import {
 	ScriptRegistry,
 } from "@obsiscripta/obsidian-script-loader";
 import { createObsidianContextConfig } from "../mcp/tools/scripting/context-config";
-import { validateAndConvertScriptExports } from "../mcp/tools/scripting/script-validator";
+import { isToolDefinitionLike, validateAndConvertScriptExports } from "../mcp/tools/scripting/script-validator";
 import { ExampleManager } from "../mcp/tools/scripting/example-manager";
 import { EventRegistrar, ScriptExecutionContext } from "./context";
 
@@ -69,6 +69,11 @@ export class ToolingManager {
 			scriptsPath,
 			{
 				onScriptLoaded: (metadata, exports) => {
+					if (!isToolDefinitionLike(exports)) {
+						console.debug(`[Bridge] Ignoring non-tool script file: ${metadata.path}`);
+						return;
+					}
+
 					try {
 						// Validate and convert script exports to MCP tool definition
 						const tool = validateAndConvertScriptExports(exports, metadata.path, metadata.name);

--- a/packages/obsidian-script-loader/src/adapters/obsidian-module-resolver.ts
+++ b/packages/obsidian-script-loader/src/adapters/obsidian-module-resolver.ts
@@ -1,0 +1,105 @@
+import { TFile, Vault } from "obsidian";
+import { ModuleResolver, PathUtils, ScriptCompiler, ScriptLoaderType } from "@obsiscripta/script-loader-core";
+
+const MODULE_EXTENSIONS: ScriptLoaderType[] = ["ts", "js"];
+
+/**
+ * Vault-backed module resolver for FunctionRuntime.
+ *
+ * Resolution rules:
+ * - Only relative specifiers ("./" or "../") are supported
+ * - Paths are resolved from the requiring file's directory
+ * - Resolution is restricted to paths inside the vault (no absolute paths, no escape above root)
+ * - Extensionless specifiers try ".ts", ".js", then "index.ts"/"index.js"
+ */
+export class ObsidianModuleResolver implements ModuleResolver {
+	private vault: Vault;
+	private pathUtils: PathUtils;
+	private compiler: ScriptCompiler;
+
+	constructor(vault: Vault, pathUtils: PathUtils) {
+		this.vault = vault;
+		this.pathUtils = pathUtils;
+		this.compiler = new ScriptCompiler();
+	}
+
+	async resolve(specifier: string, fromPath: string): Promise<string | null> {
+		if (!this.isRelativeSpecifier(specifier)) {
+			return null;
+		}
+
+		const fromDir = this.pathUtils.dirname(fromPath);
+		const requested = this.pathUtils.normalize(this.pathUtils.join(fromDir, specifier));
+		if (!this.isVaultRelativePath(requested)) {
+			return null;
+		}
+
+		for (const candidate of this.getCandidates(requested)) {
+			if (!this.isVaultRelativePath(candidate)) {
+				continue;
+			}
+			const entry = this.vault.getAbstractFileByPath(candidate);
+			if (entry instanceof TFile) {
+				return candidate;
+			}
+		}
+
+		return null;
+	}
+
+	async load(resolvedPath: string): Promise<{ code: string; mtime?: number }> {
+		const file = this.vault.getAbstractFileByPath(resolvedPath);
+		if (!(file instanceof TFile)) {
+			throw new Error(`Module file not found: ${resolvedPath}`);
+		}
+
+		const loader = this.getLoader(resolvedPath);
+		if (!loader) {
+			throw new Error(`Unsupported module type: ${resolvedPath}`);
+		}
+
+		const source = await this.vault.read(file);
+		const code = await this.compiler.compile(resolvedPath, source, loader, file.stat?.mtime);
+
+		return {
+			code,
+			mtime: file.stat?.mtime,
+		};
+	}
+
+	clearCache(): void {
+		this.compiler.clear();
+	}
+
+	private isRelativeSpecifier(specifier: string): boolean {
+		return specifier.startsWith("./") || specifier.startsWith("../");
+	}
+
+	private isVaultRelativePath(path: string): boolean {
+		if (!path || this.pathUtils.isAbsolute(path)) {
+			return false;
+		}
+		return !path.startsWith("../") && path !== "..";
+	}
+
+	private getCandidates(resolvedBase: string): string[] {
+		const hasKnownExtension = MODULE_EXTENSIONS.some(ext => resolvedBase.endsWith(`.${ext}`));
+		if (hasKnownExtension) {
+			return [resolvedBase];
+		}
+
+		const direct = MODULE_EXTENSIONS.map(ext => `${resolvedBase}.${ext}`);
+		const indexed = MODULE_EXTENSIONS.map(ext => this.pathUtils.join(resolvedBase, `index.${ext}`));
+		return [...direct, ...indexed];
+	}
+
+	private getLoader(path: string): ScriptLoaderType | null {
+		if (path.endsWith(".ts") && !path.endsWith(".d.ts")) {
+			return "ts";
+		}
+		if (path.endsWith(".js")) {
+			return "js";
+		}
+		return null;
+	}
+}

--- a/packages/obsidian-script-loader/src/index.ts
+++ b/packages/obsidian-script-loader/src/index.ts
@@ -18,6 +18,7 @@ export type { EventRegistrar } from "./adapters/obsidian-vault-adapter";
 export { ObsidianVaultAdapter } from "./adapters/obsidian-vault-adapter";
 export { ObsidianPathUtils } from "./adapters/obsidian-path-utils";
 export { ObsidianLogger } from "./adapters/obsidian-logger";
+export { ObsidianModuleResolver } from "./adapters/obsidian-module-resolver";
 
 // ============================================================================
 // Re-export core classes for convenience

--- a/packages/obsidian-script-loader/src/script-loader.ts
+++ b/packages/obsidian-script-loader/src/script-loader.ts
@@ -13,6 +13,7 @@ import { ScriptExecutionContext } from "./types";
 import { ObsidianVaultAdapter, EventRegistrar } from "./adapters/obsidian-vault-adapter";
 import { ObsidianPathUtils } from "./adapters/obsidian-path-utils";
 import { ObsidianLogger } from "./adapters/obsidian-logger";
+import { ObsidianModuleResolver } from "./adapters/obsidian-module-resolver";
 
 /**
  * Obsidian-specific wrapper for ScriptLoaderCore.
@@ -113,11 +114,12 @@ export class ScriptLoader {
 	 */
 	static createRuntime(
 		contextConfig: ExecutionContextConfig,
-		_vault: Vault,
+		vault: Vault,
 		options?: FunctionRuntimeOptions
 	): ScriptRuntime {
 		const pathUtils = options?.pathUtils ?? new ObsidianPathUtils();
-		const runtimeOptions: FunctionRuntimeOptions = { ...options, pathUtils };
+		const moduleResolver = options?.moduleResolver ?? new ObsidianModuleResolver(vault, pathUtils);
+		const runtimeOptions: FunctionRuntimeOptions = { ...options, pathUtils, moduleResolver };
 
 		return new FunctionRuntime(contextConfig, runtimeOptions);
 	}
@@ -127,8 +129,8 @@ export class ScriptLoader {
 	 */
 	static createExecutor(
 		contextConfig: ExecutionContextConfig,
-		_vault: Vault
+		vault: Vault
 	): ScriptRuntime {
-		return ScriptLoader.createRuntime(contextConfig, _vault);
+		return ScriptLoader.createRuntime(contextConfig, vault);
 	}
 }


### PR DESCRIPTION
### Motivation

- Allow scripts in the `mcp-tools` folder to `require()` relative helper modules without introducing a separate shared-module directory. 
- Restrict module resolution to the Vault to prevent loading files outside the vault or via absolute paths. 
- Ensure the loader tolerates non-tool files (helper modules, assets) in the same folder by ignoring them instead of treating them as invalid tools.

### Description

- Add `ObsidianModuleResolver` which implements `ModuleResolver` and resolves only relative specifiers (`./`/`../`) to vault-relative `.ts`/`.js` files and `index.*` fallbacks. 
- Wire `ScriptLoader.createRuntime()` to provide the new `ObsidianModuleResolver` by default so `FunctionRuntime` gets resolver-backed `require()` semantics. 
- Export `ObsidianModuleResolver` from the Obsidian wrapper package so it can be referenced externally. 
- Add `isToolDefinitionLike()` and update the tooling flow to skip non-tool script files (log debug and ignore) before validating and registering tool definitions.

### Testing

- Built packages with `pnpm --filter @obsiscripta/script-loader-core run build`, `pnpm --filter @obsiscripta/obsidian-script-loader run build`, and `pnpm --filter obsiscripta-bridge-plugin run build`, and the builds succeeded. 
- Ran unit tests with `pnpm --filter @obsiscripta/script-loader-core run test` and all tests passed (`108 tests` across 6 files). 
- Ran linters with `pnpm --filter @obsiscripta/obsidian-script-loader run lint` and `pnpm --filter obsiscripta-bridge-plugin run lint`, and linting completed without errors. 
- Verified `tsc` compilation for the affected packages after changes and resolved dependency build order where needed, with successful output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698adda9f60c8329a1efdae4f2249268)