### PR TITLE
Fix MCP server lint issues in request parsing path

### DIFF
--- a/packages/obsidian-plugin/src/mcp/server.ts
+++ b/packages/obsidian-plugin/src/mcp/server.ts
@@ -10,7 +10,6 @@ import {
 	createParseErrorResponse,
 	createInvalidRequestResponse,
 } from "./mcp-api";
-import type { JSONRPCRequest } from "./mcp-types";
 
 export class BridgeServer {
 	private static readonly MAX_BODY_BYTES = 1024 * 1024;
@@ -179,7 +178,7 @@ export class BridgeServer {
 			let body: unknown;
 			try {
 				body = await c.req.json();
-			} catch (error) {
+			} catch {
 				const errorResponse = createParseErrorResponse();
 				return c.json(errorResponse, 400);
 			}
@@ -193,7 +192,7 @@ export class BridgeServer {
 				return c.json(errorResponse, 400);
 			}
 
-			const request = parsed as JSONRPCRequest;
+			const request = parsed;
 
 			// Handle the request
 			try {


### PR DESCRIPTION
### Motivation
- Linting flagged issues in the MCP HTTP handler (unused catch variable and unnecessary type assertion) that caused `pnpm run lint` to fail for the plugin package.

### Description
- Remove the unused `catch (error)` variable and switch to a `catch { ... }` block in the `/mcp` JSON parsing path to satisfy `@typescript-eslint/no-unused-vars`.
- Remove an unnecessary type assertion (`as JSONRPCRequest`) after `parseJSONRPCMessage` has already been narrowed by the `instanceof Error` check to satisfy `@typescript-eslint/no-unnecessary-type-assertion`.
- Drop the now-unused `JSONRPCRequest` type import from `packages/obsidian-plugin/src/mcp/server.ts`.

### Testing
- Ran `pnpm run lint` and confirmed linting completed successfully for the workspace (plugin lint now passes). 
- Ran `pnpm --filter obsiscripta-bridge-plugin run build` and confirmed the plugin build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ae44800988329814d3d554576bffe)