### PR TITLE
ci: run workspace tests in GitHub Actions workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,4 +26,4 @@ jobs:
             - run: pnpm install
             - run: pnpm run build
             - run: pnpm run lint
-
+            - run: pnpm run test


### PR DESCRIPTION
### Motivation
- Ensure the workspace test suite runs on CI for push and PR events so build/lint and tests are validated across Node 20.x and 22.x.

### Description
- Add a `pnpm run test` step to the existing CI job in `.github/workflows/lint.yml` so the workflow runs tests after `pnpm run build` and `pnpm run lint`.

### Testing
- Ran `pnpm install` locally and then `pnpm run test`, and the workspace tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698aeed60e6c8329a8d91835958576ec)