### PR TITLE
feat(plugin): resolve vault links in read_note output

### DIFF
--- a/packages/obsidian-plugin/src/__tests__/mocks/obsidian.ts
+++ b/packages/obsidian-plugin/src/__tests__/mocks/obsidian.ts
@@ -67,8 +67,11 @@ export class Plugin {
 
 // Re-export types
 export type TAbstractFile = any;
-export type TFile = any;
-export type TFolder = any;
+export class TFile {
+	path = "";
+	basename = "";
+}
+export class TFolder {}
 
 // Path normalization function
 export function normalizePath(path: string): string {

--- a/packages/obsidian-plugin/src/__tests__/unit/notes-tool.test.ts
+++ b/packages/obsidian-plugin/src/__tests__/unit/notes-tool.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from "vitest";
+import { TFile } from "obsidian";
+import { readNoteTool } from "../../mcp/tools/builtin/notes";
+
+function createTFile(path: string, basename: string): TFile {
+	const file = new TFile();
+	Object.assign(file, { path, basename });
+	return file;
+}
+
+describe("read_note tool", () => {
+	it("resolves wiki links when resolveLinks=true", async () => {
+		const sourceFile = createTFile("Notes/Daily.md", "Daily");
+		const targetFile = createTFile("Projects/Plan.md", "Plan");
+
+		const context = {
+			vault: {
+				getAbstractFileByPath: vi.fn().mockReturnValue(sourceFile),
+				read: vi.fn().mockResolvedValue("Go to [[Plan]] and [[Plan#Roadmap|roadmap section]]"),
+			},
+			app: {
+				metadataCache: {
+					getFirstLinkpathDest: vi.fn().mockImplementation((linkPath: string) => {
+						if (linkPath === "Plan") {
+							return targetFile;
+						}
+						return null;
+					}),
+				},
+			},
+		} as any;
+
+		const result = await readNoteTool.handler({ path: "Notes/Daily", resolveLinks: true }, context);
+		expect(result.isError).toBeUndefined();
+		expect(result.content[0]?.text).toBe(
+			"Go to [Plan](Projects/Plan.md) and [roadmap section](Projects/Plan.md#Roadmap)",
+		);
+	});
+
+	it("keeps original markdown when resolveLinks is omitted", async () => {
+		const sourceFile = createTFile("Notes/Daily.md", "Daily");
+		const context = {
+			vault: {
+				getAbstractFileByPath: vi.fn().mockReturnValue(sourceFile),
+				read: vi.fn().mockResolvedValue("Go to [[Plan]]"),
+			},
+			app: {
+				metadataCache: {
+					getFirstLinkpathDest: vi.fn().mockReturnValue(createTFile("Projects/Plan.md", "Plan")),
+				},
+			},
+		} as any;
+
+		const result = await readNoteTool.handler({ path: "Notes/Daily" }, context);
+		expect(result.content[0]?.text).toBe("Go to [[Plan]]");
+	});
+});

--- a/packages/obsidian-plugin/src/mcp/tools/builtin/notes.ts
+++ b/packages/obsidian-plugin/src/mcp/tools/builtin/notes.ts
@@ -1,6 +1,61 @@
 import { normalizePath, TFile } from "obsidian";
 import { MCPToolDefinition, MCPToolResult } from "../types";
 
+interface ObsidianLinkParts {
+	linkPath: string;
+	subpath: string;
+	displayText: string;
+}
+
+function parseObsidianLink(rawLink: string): ObsidianLinkParts {
+	const [targetRaw, displayRaw] = rawLink.split("|");
+	const target = targetRaw?.trim() ?? "";
+	const displayText = displayRaw?.trim() ?? "";
+
+	const hashIndex = target.indexOf("#");
+	if (hashIndex === -1) {
+		return {
+			linkPath: target,
+			subpath: "",
+			displayText
+		};
+	}
+
+	return {
+		linkPath: target.slice(0, hashIndex).trim(),
+		subpath: target.slice(hashIndex + 1).trim(),
+		displayText
+	};
+}
+
+function resolveVaultLinks(
+	markdown: string,
+	sourceFilePath: string,
+	context: Parameters<MCPToolDefinition["handler"]>[1]
+): string {
+	return markdown.replace(/(!)?\[\[([^\]\n]+)\]\]/g, (match, embedPrefix, rawLink: string) => {
+		const { linkPath, subpath, displayText } = parseObsidianLink(rawLink);
+		if (!linkPath) {
+			return match;
+		}
+
+		const resolvedFile = context.app.metadataCache.getFirstLinkpathDest(linkPath, sourceFilePath);
+		if (!resolvedFile) {
+			return match;
+		}
+
+		const label = displayText || resolvedFile.basename || linkPath;
+		const anchorSuffix = subpath ? `#${subpath}` : "";
+		const resolvedPath = `${resolvedFile.path}${anchorSuffix}`;
+
+		if (embedPrefix) {
+			return `![${label}](${resolvedPath})`;
+		}
+
+		return `[${label}](${resolvedPath})`;
+	});
+}
+
 /**
  * Built-in tool: read_note
  * Reads the content of a note from the vault
@@ -14,12 +69,17 @@ export const readNoteTool: MCPToolDefinition = {
 			path: {
 				type: "string",
 				description: "Path to the note (e.g., 'folder/note.md' or 'note'). The .md extension is optional."
+			},
+			resolveLinks: {
+				type: "boolean",
+				description: "If true, converts Obsidian vault links ([[...]] / ![[...]]) in the note body to resolved markdown links using vault-relative paths."
 			}
 		},
 		required: ["path"]
 	},
 	handler: async (args, context): Promise<MCPToolResult> => {
 		const path = args.path as string;
+		const resolveLinks = args.resolveLinks === true;
 
 		// Normalize path using Obsidian's helper (handles path separators)
 		let normalizedPath = normalizePath(path);
@@ -54,10 +114,11 @@ export const readNoteTool: MCPToolDefinition = {
 
 		try {
 			const content = await context.vault.read(file);
+			const output = resolveLinks ? resolveVaultLinks(content, file.path, context) : content;
 			return {
 				content: [{
 					type: "text",
-					text: content
+					text: output
 				}]
 			};
 		} catch (error) {


### PR DESCRIPTION
### Motivation
- Allow built-in `read_note` tool to return markdown with Obsidian-style vault links resolved so callers can follow links or render them outside Obsidian.
- Preserve existing behavior by making link resolution opt-in to avoid changing existing consumers.

### Description
- Added `resolveLinks` boolean input to the `read_note` tool schema and handler to control conversion of `[[...]]` and `![[...]]` links.
- Implemented `parseObsidianLink` and `resolveVaultLinks` to parse wiki links (including `#subpath` and `alias|display`) and resolve targets via `metadataCache.getFirstLinkpathDest`, converting resolved links to standard markdown links or image embeds using the vault-relative file path.
- Updated `read_note` handler to optionally post-process note content with `resolveVaultLinks` when `resolveLinks` is true.
- Added focused unit tests (`src/__tests__/unit/notes-tool.test.ts`) covering resolved and default behaviors, and adjusted the test Obsidian mock to export a runtime `TFile` so `instanceof TFile` checks work in tests.

### Testing
- Ran targeted unit tests: `pnpm --filter obsiscripta-bridge-plugin exec vitest run src/__tests__/unit/notes-tool.test.ts` — tests passed (2 tests, both succeeded).
- Built the plugin package: `pnpm --filter obsiscripta-bridge-plugin run build` — build succeeded after the test mock adjustments.
- Linted the plugin: `pnpm --filter obsiscripta-bridge-plugin run lint` — lint completed with no errors.
- Note: running the workspace-wide `pnpm --filter obsiscripta-bridge-plugin run test -- <file>` can exercise other suites and initially surfaced unrelated package entry resolution errors in the workspace; the isolated `vitest` run above was used to validate the changes for this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b79252d6c8329b597815c99028bc7)