### PR TITLE
docs: replace require example with helper-module sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,9 +191,69 @@ export default {
 Notes:
 
 - Relative imports resolve from the script file location.
+- CommonJS `require(...)` can also be used in script tools (Node built-ins like `path` / `fs`, and local CommonJS files).
 - If Dataview is installed, `dv` (Dataview API) is available.
 - If Templater is installed, `tp` (Templater API) is available.
 - If Omnisearch is installed, the global `omnisearch` API is available.
+
+Detailed `require` example:
+
+Place the following two files under `mcp-tools/`.
+
+`mcp-tools/require_example.js`
+
+```js
+export default {
+  description: "Exercise require-based module loading from a helper module.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      name: { type: "string" },
+    },
+  },
+  handler: async (args) => {
+    const helper = require("./require-helper");
+    const message = typeof helper?.buildMessage === "function"
+      ? helper.buildMessage(args?.name)
+      : "require helper missing buildMessage";
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: message,
+        },
+      ],
+    };
+  },
+};
+```
+
+`mcp-tools/require-helper.js`
+
+```js
+const buildMessage = (name) => {
+  const value = typeof name === "string" && name.trim() ? name.trim() : "world";
+  return `require-ok: hello ${value}`;
+};
+
+module.exports = {
+  buildMessage,
+};
+```
+
+Example input:
+
+```json
+{ "name": "Obsidian" }
+```
+
+Example output (`content[0].text`):
+
+```text
+require-ok: hello Obsidian
+```
+
 
 Examples:
 


### PR DESCRIPTION
### Motivation
- The existing `require` example included a runtime availability branch that diverged from expected usage patterns and caused confusion.
- Provide a concise, realistic example demonstrating CommonJS `require` usage with a helper module used by script tools.

### Description
- Replaced the `Detailed require example` in `README.md` with a two-file sample under `mcp-tools/`: `require_example.js` and `require-helper.js`.
- Removed the `typeof require !== "function"` error-handling branch and show direct `require("./require-helper")` usage in the handler.
- Updated the example input and output to show `require-ok: hello Obsidian` as the sample `content[0].text`.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b80ad64f48329b61956bfc55db9c1)